### PR TITLE
fix: update offset after append / prepend

### DIFF
--- a/src/ByteBuffer.php
+++ b/src/ByteBuffer.php
@@ -262,7 +262,9 @@ class ByteBuffer
 
         $buffer = array_merge($this->buffer, $value);
 
-        $this->initializeBuffer(count($buffer), $buffer);
+        $bufferCount = count($buffer);
+        $this->initializeBuffer($bufferCount, $buffer);
+        $this->position($bufferCount); // move current offset to the end of merged buffer after append
 
         return $this;
     }
@@ -304,7 +306,9 @@ class ByteBuffer
             array_unshift($buffer, $item);
         }
 
-        $this->initializeBuffer(count($buffer), $buffer);
+        $bufferCount = count($buffer);
+        $this->initializeBuffer($bufferCount, $buffer);
+        $this->position($bufferCount); // move current offset to the end of merged buffer after prepend
 
         return $this;
     }

--- a/tests/ByteBufferTest.php
+++ b/tests/ByteBufferTest.php
@@ -166,6 +166,7 @@ class ByteBufferTest extends TestCase
         $buffer->append(ByteBuffer::new('World'));
 
         $this->assertSame('HelloWorld', $buffer->toUTF8());
+        $this->assertSame($buffer->capacity(), $buffer->current()); // offset should be at the end of new buffer
     }
 
     /** @test */
@@ -175,6 +176,7 @@ class ByteBufferTest extends TestCase
         $buffer->append('World');
 
         $this->assertSame('HelloWorld', $buffer->toUTF8());
+        $this->assertSame($buffer->capacity(), $buffer->current()); // offset should be at the end of new buffer
     }
 
     /** @test */
@@ -185,6 +187,7 @@ class ByteBufferTest extends TestCase
         ByteBuffer::new('World')->appendTo($buffer);
 
         $this->assertSame('HelloWorld', $buffer->toUTF8());
+        $this->assertSame($buffer->capacity(), $buffer->current()); // offset should be at the end of new buffer
     }
 
     /** @test */
@@ -194,6 +197,7 @@ class ByteBufferTest extends TestCase
         $buffer->prepend(ByteBuffer::new('Hello'));
 
         $this->assertSame('HelloWorld', $buffer->toUTF8());
+        $this->assertSame($buffer->capacity(), $buffer->current()); // offset should be at the end of new buffer
     }
 
     /** @test */
@@ -203,6 +207,7 @@ class ByteBufferTest extends TestCase
         $buffer->prepend('Hello');
 
         $this->assertSame('HelloWorld', $buffer->toUTF8());
+        $this->assertSame($buffer->capacity(), $buffer->current()); // offset should be at the end of new buffer
     }
 
     /** @test */
@@ -213,6 +218,7 @@ class ByteBufferTest extends TestCase
         ByteBuffer::new('Hello')->prependTo($buffer);
 
         $this->assertSame('HelloWorld', $buffer->toUTF8());
+        $this->assertSame($buffer->capacity(), $buffer->current()); // offset should be at the end of new buffer
     }
 
     /** @test */


### PR DESCRIPTION
Move offset to the end of resulting buffer after append and prepend.