### PR TITLE
fix: fill start by default from current offset

### DIFF
--- a/src/ByteBuffer.php
+++ b/src/ByteBuffer.php
@@ -336,9 +336,13 @@ class ByteBuffer
      */
     public function fill(int $length, int $start = 0): self
     {
-        $this->buffer = array_fill($start, $length, pack('x'));
+        if ($start > 0) {
+            $this->position($start);
+        }
 
-        $this->skip($length);
+        for ($i = 0; $i < $length; $i++) {
+            $this->buffer[$this->offset++] = pack('x');
+        }
 
         return $this;
     }

--- a/tests/ByteBufferTest.php
+++ b/tests/ByteBufferTest.php
@@ -231,6 +231,16 @@ class ByteBufferTest extends TestCase
     }
 
     /** @test */
+    public function it_should_fill_the_buffer_starting_from_current_position()
+    {
+        $buffer = ByteBuffer::new("hello");
+        $buffer->position(4);
+        $buffer->fill(11);
+
+        $this->assertSame(4 + 11, $buffer->internalSize());
+    }
+
+    /** @test */
     public function it_should_flip_the_buffer_contents()
     {
         $buffer = ByteBuffer::new('Hello World');


### PR DESCRIPTION
Fix `fill` behavior which was just erasing current buffer with filled bytes.

Now it fills from current offset unless the offset is specified, and preserving current buffer.